### PR TITLE
add --no-startup-id flag to dmenu binding

### DIFF
--- a/config/i3
+++ b/config/i3
@@ -83,7 +83,7 @@ bindsym $mod+i exec i3-input
 bindsym $mod+Shift+x exec i3lock -i ~/.i3/desktop.jpg
 
 # Trigger dmenu
-bindsym $mod+d exec --no-startup-id dmenu_run 
+bindsym $mod+d exec --no-startup-id dmenu_run
 
 # Kill focused window
 bindsym $mod+Shift+q kill

--- a/config/i3
+++ b/config/i3
@@ -83,7 +83,7 @@ bindsym $mod+i exec i3-input
 bindsym $mod+Shift+x exec i3lock -i ~/.i3/desktop.jpg
 
 # Trigger dmenu
-bindsym $mod+d exec dmenu_run
+bindsym $mod+d exec --no-startup-id dmenu_run 
 
 # Kill focused window
 bindsym $mod+Shift+q kill


### PR DESCRIPTION
Prevents dmenu from getting stuck on wait cursor if you exit dmenu without making a selection
